### PR TITLE
Production deployment test

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -13,7 +13,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist/frontierEosNameGenerator",
+            "outputPath": "dist",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --prod=true --optimization=true --source-map=false --disable-host-check=true",
-    "build": "ng build",
+    "build": "ng build -aot",
+    "server": "ng build --aot --prod && http-server ./dist -p 4200",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"
@@ -20,6 +21,7 @@
     "@angular/platform-browser-dynamic": "~7.1.0",
     "@angular/router": "~7.1.0",
     "core-js": "^2.5.4",
+    "http-server": "^0.11.1",
     "rxjs": "~6.3.3",
     "tslib": "^1.9.0",
     "zone.js": "~0.8.26"


### PR DESCRIPTION
- Installed http-server package
- Changed "build" output path
- Added 'npm run server' script
- Port is set to "4200" default, because I am unaware which port the namegen is using on the eos server at the moment.